### PR TITLE
Fixed a typo that prevent aee option from working.

### DIFF
--- a/template/metu.cls
+++ b/template/metu.cls
@@ -133,7 +133,7 @@
 	\def\@tdepartment{\csname @tdept#1\endcsname}
 }
 \DeclareOption{ceng}{\DeclareDepartment{ceng}}
-\DeclareOption{aee}{\DeclareDepartment{aeee}}
+\DeclareOption{aee}{\DeclareDepartment{aee}}
 \DeclareOption{arme}{\DeclareDepartment{arme}}
 \DeclareOption{arch}{\DeclareDepartment{arch}}
 \DeclareOption{bch}{\DeclareDepartment{bch}}


### PR DESCRIPTION
Fixed aee option declaring wrong deparment, which resulted in empty deparment names.